### PR TITLE
[Feat]: 그룹 설정 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Outlet } from "react-router-dom";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 function App() {
   return (

--- a/src/components/Header/HeaderBackChatNotify.tsx
+++ b/src/components/Header/HeaderBackChatNotify.tsx
@@ -4,13 +4,13 @@ import { TbMessageChatbot } from "react-icons/tb";
 import { FaRegBell } from "react-icons/fa6";
 
 function HeaderBackChatNotify() {
-  const { goToHome } = useNavigation();
+  const { goToBack } = useNavigation();
 
   return (
     <header className="flex items-center justify-between p-2 bg-[#F5F6FA] shadow-md h-[44px]">
       <IoChevronBackOutline
         className="text-[24px] cursor-pointer"
-        onClick={goToHome}
+        onClick={goToBack}
       />
       <div className="flex items-center">
         <TbMessageChatbot className="text-[24px] cursor-pointer" />

--- a/src/components/Header/HeaderBackSetting.tsx
+++ b/src/components/Header/HeaderBackSetting.tsx
@@ -3,15 +3,18 @@ import { IoChevronBackOutline } from "react-icons/io5";
 import { CiSettings } from "react-icons/ci";
 
 function HeaderBackSetting() {
-  const { goToHome } = useNavigation();
+  const { goToBack, goToGroupSettings } = useNavigation();
 
   return (
-    <header className="flex items-center justify-between p-2 bg-[#F5F6FA] shadow-md h-[44px]">
+    <header className="flex items-center justify-between p-2 bg-backGround shadow-md h-[44px]">
       <IoChevronBackOutline
         className="text-[24px] cursor-pointer"
-        onClick={goToHome}
+        onClick={goToBack}
       />
-      <CiSettings className="text-[24px] cursor-pointer" />
+      <CiSettings
+        className="text-[24px] cursor-pointer"
+        onClick={goToGroupSettings}
+      />
     </header>
   );
 }

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -9,6 +9,7 @@ export const useNavigation = () => {
   const goToAddGroupMember = () => navigate("/addGroupMember");
   const goToGroupMemberList = () => navigate("/groupMemberList");
   const goToMemberSettings = () => navigate("/memberSettings");
+  const goToGroupSettings = () => navigate("/groupSettings");
   const goToPaymentRequest = () => navigate("/paymentRequest");
   const goToVerification = () => navigate("/verification");
   const goToSignUp = () => navigate("/signup");
@@ -21,6 +22,7 @@ export const useNavigation = () => {
     goToAddGroupMember,
     goToGroupMemberList,
     goToMemberSettings,
+    goToGroupSettings,
     goToPaymentRequest,
     goToVerification,
     goToSignUp,

--- a/src/pages/GroupSettingsPage.tsx
+++ b/src/pages/GroupSettingsPage.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import HeaderBackChatNotify from "@/components/Header/HeaderBackChatNotify";
+import InputField from "@/components/common/InputField";
+import { updateGroupSettings } from "@/services/groupSettingsService";
+import { GroupSettings } from "@/types/GroupSettings";
+import { useNavigation } from "@/hooks/useNavigation";
+
+const family_id = "1";
+
+const GroupSettingsPage = () => {
+  const [groupSettings, setGroupSettings] = useState<GroupSettings>({
+    groupName: "신한이네",
+    groupMotto: "건강이 최고",
+    approvalLimit: 1,
+    creationDate: "2024.08.29",
+  });
+  const { goToBack } = useNavigation();
+
+  const handleInputChange = (key: keyof GroupSettings) => (value: string) => {
+    setGroupSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSaveSettings = async () => {
+    try {
+      await updateGroupSettings(family_id, groupSettings);
+      alert("그룹 설정이 성공적으로 저장되었습니다.");
+      goToBack();
+    } catch (error) {
+      console.error("그룹 설정 저장 실패:", error);
+      alert("그룹 설정 저장에 실패했습니다.");
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <HeaderBackChatNotify />
+      <main className="flex px-4 py-6 flex-col justify-between">
+        <h1 className="text-xl font-bold text-Button mb-2">그룹 설정</h1>
+        <div className="flex flex-col bg-white rounded-lg p-4 items-end">
+          <InputField
+            label="그룹명"
+            placeholder="그룹명을 입력해주세요."
+            value={groupSettings.groupName}
+            onChange={handleInputChange("groupName")}
+          />
+          <InputField
+            label="그룹 표어"
+            placeholder="그룹 표어를 입력해주세요."
+            value={groupSettings.groupMotto}
+            onChange={handleInputChange("groupMotto")}
+          />
+          <InputField
+            label="승인 인원 숫자"
+            placeholder="승인 인원 숫자를 입력해주세요."
+            type="number"
+            value={groupSettings.approvalLimit.toString()}
+            onChange={(value) => handleInputChange("approvalLimit")(value)}
+          />
+          <div className="w-full mb-8 text-grey">
+            <label className="block text-md font-semibold mb-2">
+              그룹 개설일
+            </label>
+            <div className="w-full border-b-2 border-grey p-2 text-lg">
+              {groupSettings.creationDate}
+            </div>
+          </div>
+          <button
+            className="text-grey font-semibold text-lg mt-5 me-2 cursor-pointer hover:text-Button"
+            onClick={handleSaveSettings}
+          >
+            저장
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default GroupSettingsPage;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,15 +1,16 @@
 import { createBrowserRouter } from "react-router-dom";
 import App from "@/App";
-import AddGroupMemberPage from "@/pages/AddGroupMemberPage";
 import MainPage from "@/pages/MainPage";
 import PaymentRequestPage from "@/pages/PaymentRequestPage";
 import VerificationCodePage from "@/pages/VerificationCodePage";
+import AddGroupMemberPage from "@/pages/AddGroupMemberPage";
 import GroupMemberListPage from "@/pages/GroupMemberListPage";
-import QuestionBankPage from "@/pages/QuestionBankPage";
+import MemberSettingsPage from "@/pages/MemberSettingsPage";
+import GroupSettingsPage from "@/pages/GroupSettingsPage";
 import GuardianExamPage from "@/pages/GuardianExamPage";
+import QuestionBankPage from "@/pages/QuestionBankPage";
 import SignUpPage from "@/pages/SignUpPage";
 import LoginPage from "@/pages/LoginPage";
-import MemberSettingsPage from "@/pages/MemberSettingsPage";
 
 const router = createBrowserRouter([
   {
@@ -31,6 +32,10 @@ const router = createBrowserRouter([
       {
         path: "memberSettings",
         element: <MemberSettingsPage />,
+      },
+      {
+        path: "groupSettings",
+        element: <GroupSettingsPage />,
       },
       {
         path: "paymentRequest",

--- a/src/services/groupSettingsService.ts
+++ b/src/services/groupSettingsService.ts
@@ -1,0 +1,24 @@
+import axiosInstance from "./axiosInstance";
+import { GroupSettings } from "@/types/GroupSettings";
+
+export const updateGroupSettings = async (
+  family_id: string,
+  settings: GroupSettings
+): Promise<void> => {
+  try {
+    const response = await axiosInstance.put(`/family/${family_id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(settings),
+    });
+
+    if (!response) {
+      throw new Error("Failed to update group settings");
+    }
+  } catch (error) {
+    console.error("Error updating group settings:", error);
+    throw error;
+  }
+};

--- a/src/types/GroupSettings.ts
+++ b/src/types/GroupSettings.ts
@@ -1,0 +1,6 @@
+export interface GroupSettings {
+  groupName: string;
+  groupMotto: string;
+  approvalLimit: number;
+  creationDate: string;
+}


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- #29 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- 그룹 설정 페이지 구현

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- router 추가
- navigation 추가
- 헤더의 back 기능 main에서 back으로 수정
- 그룹 설정 페이지 구현
- 그룹 설정 수정 api 대략 구현

## 기타 <!-- 기타 공유할 내용이 있다면 작성해주세요. -->

![image](https://github.com/user-attachments/assets/20b18cb7-d0e7-4697-b8d8-45d7df4389ca)
