### PR TITLE
[Feat]: 시험 관련 api 함수 구현

### DIFF
--- a/src/components/Question/ResultModal.tsx
+++ b/src/components/Question/ResultModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Button from "@/components/common/Button";
 import { useNavigation } from "@/hooks/useNavigation";
+import { PASS_THRESHOLD } from "@/constant/common";
 
 interface ResultModalProps {
   isOpen: boolean;
@@ -9,8 +10,7 @@ interface ResultModalProps {
 }
 
 const ResultModal: React.FC<ResultModalProps> = ({ isOpen, correctAnswers, totalQuestions }) => {
-  const passThreshold = Math.ceil(totalQuestions * 0.7); // 70% 이상 맞추면 합격
-  const isPassed = correctAnswers >= passThreshold;
+  const isPassed = correctAnswers >= PASS_THRESHOLD;
   const { goToHome } = useNavigation();
 
   if (!isOpen) return null;

--- a/src/constant/common.ts
+++ b/src/constant/common.ts
@@ -1,2 +1,3 @@
 export const TOTAL_COUNT = 12;
 export const QUESTION_TIME = 15; // 각 문제당 10초
+export const PASS_THRESHOLD = 18;

--- a/src/pages/GuardianExamPage.tsx
+++ b/src/pages/GuardianExamPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { getQuestions } from "@/services/questionService";
+import { getQuestions, postQuestionComplete } from "@/services/questionService";
 import { Question } from "@/types/Question";
 import { ButtonType } from "@/types/AnswerButton";
 import { QUESTION_TIME } from "@/constant/common";
@@ -107,8 +107,13 @@ const GuardianExamPage: React.FC = () => {
     }
   };
 
-  const handleShowResults = () => {
-    setShowModal(true);
+  const handleResults = async (correctAnswers: number) => {
+    try {
+      await postQuestionComplete(correctAnswers >= PASS_THRESHOLD);
+      setShowModal(true);
+    } catch (error) {
+      console.error("Failed to post question completion:", error);
+    }
   };
 
   if (loading) return <Loading />;
@@ -144,6 +149,7 @@ const GuardianExamPage: React.FC = () => {
       </main>
       <div className="p-4">
         <button
+          type="button"
           onClick={handleNextQuestion}
           disabled={!showResult || isLastQuestion}
           className="w-full bg-Button text-white py-3 rounded-lg disabled:bg-gray-300 mx-auto max-w-md hover:bg-blue-600"
@@ -151,7 +157,8 @@ const GuardianExamPage: React.FC = () => {
           다음
         </button>
         <button
-          onClick={handleShowResults}
+          type="button"
+          onClick={() => handleResults(correctAnswers)}
           disabled={!showResult || !isLastQuestion}
           className="w-full bg-Button text-white py-3 mt-4 rounded-lg disabled:bg-gray-300 mx-auto max-w-md hover:bg-blue-600"
         >

--- a/src/pages/QuestionBankPage.tsx
+++ b/src/pages/QuestionBankPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { getQuestions } from "@/services/questionService";
+import { getPractice } from "@/services/questionService";
 import { Question } from "@/types/Question";
 import { ButtonType } from "@/types/AnswerButton";
 import HeaderBackChatNotify from "@/components/Header/HeaderBackChatNotify";
@@ -19,7 +19,7 @@ const QuestionBankPage: React.FC = () => {
   useEffect(() => {
     const fetchQuestions = async () => {
       try {
-        const data = await getQuestions();
+        const data = await getPractice();
         setQuestions(data);
       } catch (error) {
         console.error("질문을 불러오는데 실패했습니다", error);
@@ -94,7 +94,6 @@ const QuestionBankPage: React.FC = () => {
         </button>
         <button
           onClick={handleGuardianExamClick}
-          disabled={!isLastQuestion || selectedAnswer === null}
           className="w-full bg-Button text-white py-3 mt-4 rounded-lg disabled:bg-gray-300 mx-auto max-w-md hover:bg-blue-600"
         >
           시험 보러가기

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -1,17 +1,36 @@
-import axiosInstance from './axiosInstance';
+import axiosInstance from "./axiosInstance";
 import { Question } from "@/types/Question";
-import { financeQuestions as dummyFinanceQuestions } from "@/utils/data";
+// import { financeQuestions as dummyFinanceQuestions } from "@/utils/data";
 
+// 가디언 시험 파트
 const getQuestions = async (): Promise<Question[]> => {
-    return dummyFinanceQuestions;
-    try {
-        const response = await axiosInstance.get('/question');
-        return response.data;
-    } catch (error) {
-        console.error('Failed to fetch question bank', error);
-        throw error;
-    }
+  try {
+    const response = await axiosInstance.get("/question");
+    return response.data;
+  } catch (error) {
+    console.error("Failed to get question", error);
+    throw error;
+  }
 };
 
+const postQuestionComplete = async (isPassed: boolean): Promise<void> => {
+  try {
+    await axiosInstance.post<Question[]>("/question/practice", { isPassed });
+  } catch (error) {
+    console.error("Failed to post question result:", error);
+    throw error;
+  }
+};
 
-export { getQuestions };
+// 문제은행 파트
+const getPractice = async (): Promise<Question[]> => {
+  try {
+    const response = await axiosInstance.get("/question");
+    return response.data;
+  } catch (error) {
+    console.error("Failed to get practice", error);
+    throw error;
+  }
+};
+
+export { getQuestions, postQuestionComplete, getPractice };

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -1,9 +1,10 @@
 import axiosInstance from "./axiosInstance";
 import { Question } from "@/types/Question";
-// import { financeQuestions as dummyFinanceQuestions } from "@/utils/data";
+import { financeQuestions as dummyFinanceQuestions } from "@/utils/data";
 
 // 가디언 시험 파트
 const getQuestions = async (): Promise<Question[]> => {
+  return dummyFinanceQuestions;
   try {
     const response = await axiosInstance.get("/question");
     return response.data;
@@ -24,6 +25,7 @@ const postQuestionComplete = async (isPassed: boolean): Promise<void> => {
 
 // 문제은행 파트
 const getPractice = async (): Promise<Question[]> => {
+  return dummyFinanceQuestions;
   try {
     const response = await axiosInstance.get("/question");
     return response.data;


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- #55 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- 시험 관련 api 함수 구현

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- 문제 받아오는 api 함수 추가
- 시험 결과 전송하는 api 함수 추가
- 문제은행 페이지에서 시험 보러가기 상시 활성화
- 합격 상한선 constant에 추가
- 결과 모달 70% -> 18개로 변경

## 기타 <!-- 기타 공유할 내용이 있다면 작성해주세요. -->

![image](https://github.com/user-attachments/assets/5a31ef6b-3c87-48fd-a2d1-e068921dc6d9)