### PR TITLE
#51 [Feat]: 그룹 및 그룹 세팅에 관한 api 구현

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -8,6 +8,12 @@
       {
         "label": "off"
       }
+    ],
+    "axe/aria": [
+      "default",
+      {
+        "aria-valid-attr-value": "off"
+      }
     ]
   }
 }

--- a/.hintrc
+++ b/.hintrc
@@ -12,7 +12,8 @@
     "axe/aria": [
       "default",
       {
-        "aria-valid-attr-value": "off"
+        "aria-valid-attr-value": "off",
+        "aria-input-field-name": "off"
       }
     ],
     "axe/name-role-value": [

--- a/.hintrc
+++ b/.hintrc
@@ -14,6 +14,13 @@
       {
         "aria-valid-attr-value": "off"
       }
-    ]
+    ],
+    "axe/name-role-value": [
+      "default",
+      {
+        "button-name": "off"
+      }
+    ],
+    "no-inline-styles": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2887,27 +2887,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
-    },
     "node_modules/@types/express": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
@@ -2932,6 +2911,14 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -2954,11 +2941,24 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
@@ -4604,8 +4604,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
@@ -5298,6 +5297,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
+      "integrity": "sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
@@ -5405,6 +5413,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.3",
@@ -5871,6 +5885,16 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -7277,6 +7301,41 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -7992,6 +8051,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "optional": true
+    },
     "node_modules/style-to-object": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.7.tgz",
@@ -8254,6 +8325,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/src/components/GroupMemberList/GroupMemberItem.tsx
+++ b/src/components/GroupMemberList/GroupMemberItem.tsx
@@ -3,6 +3,7 @@ import GroupMemberOptions from "./GroupMemberOptions";
 import { Member } from "@/types/Member";
 import { FcBookmark } from "react-icons/fc";
 import { useNavigation } from "@/hooks/useNavigation";
+import { useAuthStore } from "@/stores/userAuthStore";
 
 // 개별적으로 이미지 임포트
 import fatherImage from "@/assets/images/groupList/아버지.svg";
@@ -36,6 +37,8 @@ const relationshipImageMap: Record<string, string> = {
 const GroupMemberItem: React.FC<Props> = ({ member, onPinToggle }) => {
   const imageSrc = relationshipImageMap[member.relationship] || etcImage;
   const { goToMemberSettings } = useNavigation();
+  const { user } = useAuthStore();
+  const isClickable = user?.role !== "MEMBER";
 
   const handleItemClick = (e: React.MouseEvent, target_user_id: number) => {
     // 옵션 버튼이나 그 하위 요소를 클릭한 경우 이벤트 전파를 막음
@@ -50,8 +53,10 @@ const GroupMemberItem: React.FC<Props> = ({ member, onPinToggle }) => {
 
   return (
     <div
-      className="relative bg-white rounded-lg shadow-md p-4 flex items-center cursor-pointer"
-      onClick={(e) => handleItemClick(e, member.id)}
+      className={`relative bg-white rounded-lg shadow-md p-4 flex items-center ${
+        isClickable ? "cursor-pointer" : "cursor-not-allowed"
+      }`}
+      onClick={(e) => isClickable && handleItemClick(e, member.id)}
     >
       <div className="flex-shrink-0 mr-4">
         <img src={imageSrc} alt={member.name} className="w-12 h-12 rounded-full" />

--- a/src/components/GroupMemberList/GroupMemberItem.tsx
+++ b/src/components/GroupMemberList/GroupMemberItem.tsx
@@ -37,7 +37,7 @@ const GroupMemberItem: React.FC<Props> = ({ member, onPinToggle }) => {
   const imageSrc = relationshipImageMap[member.relationship] || etcImage;
   const { goToMemberSettings } = useNavigation();
 
-  const handleItemClick = (e: React.MouseEvent) => {
+  const handleItemClick = (e: React.MouseEvent, target_user_id: number) => {
     // 옵션 버튼이나 그 하위 요소를 클릭한 경우 이벤트 전파를 막음
     if (
       !e.currentTarget.contains(e.target as Node) ||
@@ -45,13 +45,13 @@ const GroupMemberItem: React.FC<Props> = ({ member, onPinToggle }) => {
     ) {
       return;
     }
-    goToMemberSettings();
+    goToMemberSettings(String(target_user_id));
   };
 
   return (
     <div
       className="relative bg-white rounded-lg shadow-md p-4 flex items-center cursor-pointer"
-      onClick={handleItemClick}
+      onClick={(e) => handleItemClick(e, member.id)}
     >
       <div className="flex-shrink-0 mr-4">
         <img src={imageSrc} alt={member.name} className="w-12 h-12 rounded-full" />

--- a/src/components/Header/HeaderBackSetting.tsx
+++ b/src/components/Header/HeaderBackSetting.tsx
@@ -1,20 +1,18 @@
-import { useNavigation } from "@/hooks/useNavigation";
 import { IoChevronBackOutline } from "react-icons/io5";
 import { CiSettings } from "react-icons/ci";
+import { useAuthStore } from "@/stores/userAuthStore";
+import { useNavigation } from "@/hooks/useNavigation";
 
 function HeaderBackSetting() {
   const { goToBack, goToGroupSettings } = useNavigation();
+  const { user } = useAuthStore();
 
   return (
     <header className="flex items-center justify-between p-2 bg-backGround shadow-md h-[44px]">
-      <IoChevronBackOutline
-        className="text-[24px] cursor-pointer"
-        onClick={goToBack}
-      />
-      <CiSettings
-        className="text-[24px] cursor-pointer"
-        onClick={goToGroupSettings}
-      />
+      <IoChevronBackOutline className="text-[24px] cursor-pointer" onClick={goToBack} />
+      {user?.role !== "MEMBER" && (
+        <CiSettings className="text-[24px] cursor-pointer" onClick={goToGroupSettings} />
+      )}
     </header>
   );
 }

--- a/src/components/common/SelectField.tsx
+++ b/src/components/common/SelectField.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect } from "react";
 interface SelectFieldProps<T extends string> {
   label: string;
   options: readonly T[];
-  value: T;
+  value: string;
   onChange: (value: T) => void;
 }
 

--- a/src/constant/period.ts
+++ b/src/constant/period.ts
@@ -1,3 +1,3 @@
-export const PERIOD_OPTIONS = ["일주일", "15일", "한달"] as const;
+export const PERIOD_OPTIONS = ["DAY1", "DAY7", "DAY15", "DAY30"] as const;
 
 export type Period = (typeof PERIOD_OPTIONS)[number];

--- a/src/constant/period.ts
+++ b/src/constant/period.ts
@@ -1,0 +1,3 @@
+export const PERIOD_OPTIONS = ["일주일", "15일", "한달"] as const;
+
+export type Period = (typeof PERIOD_OPTIONS)[number];

--- a/src/constant/role.ts
+++ b/src/constant/role.ts
@@ -1,3 +1,3 @@
-export const ROLE_OPTIONS = ["Member", "Manager"] as const;
+export const ROLE_OPTIONS = ["MEMBER", "MANAGER"] as const;
 
 export type Role = (typeof ROLE_OPTIONS)[number];

--- a/src/constant/term.ts
+++ b/src/constant/term.ts
@@ -1,3 +1,0 @@
-export const TERM_OPTIONS = ["일주일", "15일", "한달"] as const;
-
-export type Term = (typeof TERM_OPTIONS)[number];

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -9,7 +9,8 @@ export const useNavigation = () => {
   const goToQuestionBank = () => navigate("/questionBank");
   const goToAddGroupMember = () => navigate("/addGroupMember");
   const goToGroupMemberList = () => navigate("/groupMemberList");
-  const goToMemberSettings = () => navigate("/memberSettings");
+  const goToMemberSettings = (target_user_id: string) =>
+    navigate(`/memberSettings/${target_user_id}`);
   const goToGroupSettings = () => navigate("/groupSettings");
   const goToPaymentRequest = () => navigate("/paymentRequest");
   const goToVerification = () => navigate("/verification");

--- a/src/pages/GroupMemberListPage.tsx
+++ b/src/pages/GroupMemberListPage.tsx
@@ -3,9 +3,11 @@ import { useAuthStore } from "@/stores/userAuthStore";
 import { getGroupMemberList } from "@/services/groupMemberService";
 import { useNavigation } from "@/hooks/useNavigation";
 import { Member } from "@/types/Member";
+
 import HeaderBackSetting from "@/components/Header/HeaderBackSetting";
 import GroupInfo from "@/components/GroupMemberList/GroupInfo";
 import GroupMemberList from "@/components/GroupMemberList/GroupMemberList";
+import Loading from "@/components/common/Loading";
 
 const GroupMemberListPage: React.FC = () => {
   const [members, setMembers] = useState<Member[]>([]);
@@ -13,6 +15,7 @@ const GroupMemberListPage: React.FC = () => {
   const [familyDescription, setFamilyDescription] =
     useState<string>("하단의 +버튼으로 그룹원을 초대해 주세요.");
   const [isAddEnabled, setIsAddEnabled] = useState(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const { user } = useAuthStore();
   const { goToAddGroupMember } = useNavigation();
 
@@ -28,6 +31,8 @@ const GroupMemberListPage: React.FC = () => {
         }
       } catch (error) {
         console.error("그룹원 목록을 불러오는 데 실패했습니다.", error);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -46,6 +51,8 @@ const GroupMemberListPage: React.FC = () => {
   const handleAddMember = () => {
     goToAddGroupMember();
   };
+
+  if (loading) return <Loading />;
 
   return (
     <div className="flex flex-col h-screen">

--- a/src/pages/GroupSettingsPage.tsx
+++ b/src/pages/GroupSettingsPage.tsx
@@ -12,8 +12,8 @@ const GroupSettingsPage = () => {
   const [groupSettings, setGroupSettings] = useState<GroupSettings>({
     name: "",
     description: "",
-    approval_requirement: 1,
-    creation_date: new Date(),
+    approval_request: 1,
+    created_at: "",
   });
   const [isLoading, setIsLoading] = useState(true);
   const { goToGroupMemberList } = useNavigation();
@@ -45,7 +45,7 @@ const GroupSettingsPage = () => {
       const settingsToUpdate: GroupSettingsRequest = {
         name: groupSettings.name,
         description: groupSettings.description,
-        approval_requirement: groupSettings.approval_requirement,
+        approval_requirement: groupSettings.approval_request,
       };
       await updateGroupSettings(family_id!, settingsToUpdate);
       alert("그룹 설정이 성공적으로 저장되었습니다.");
@@ -82,13 +82,13 @@ const GroupSettingsPage = () => {
             label="승인 인원 숫자"
             placeholder="승인 인원 숫자를 입력해주세요."
             type="number"
-            value={groupSettings.approval_requirement.toString()}
-            onChange={(value) => handleInputChange("approval_requirement")(value)}
+            value={groupSettings.approval_request.toString()}
+            onChange={(value) => handleInputChange("approval_request")(value)}
           />
           <div className="w-full mb-8 text-grey">
             <label className="block text-md font-semibold mb-2">그룹 개설일</label>
-            <div className="w-full border-b-2 border-grey p-2 text-lg">
-              {new Date(groupSettings.creation_date).toLocaleDateString()}
+            <div className="w-full border-b border-grey p-2 text-lg">
+              {groupSettings.created_at}
             </div>
           </div>
           <button

--- a/src/pages/GroupSettingsPage.tsx
+++ b/src/pages/GroupSettingsPage.tsx
@@ -47,7 +47,7 @@ const GroupSettingsPage = () => {
         description: groupSettings.description,
         approval_requirement: groupSettings.approval_requirement,
       };
-      await updateGroupSettings(settingsToUpdate);
+      await updateGroupSettings(family_id!, settingsToUpdate);
       alert("그룹 설정이 성공적으로 저장되었습니다.");
       goToGroupMemberList();
     } catch (error) {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -19,6 +19,26 @@ function MainPage() {
     setIsModalOpen(true);
   };
 
+  const renderContent = () => {
+    if (user?.level === "SUPPORTER") {
+      return <div className="text-grey text-sm">서포터는 그룹을 만들 수 없습니다.</div>;
+    } else if (user?.level === "GUARDIAN") {
+      if (user.role === "MEMBER") {
+        return <div className="text-grey text-sm">MEMBER는 권한이 없습니다.</div>;
+      } else if (user.role === "NONE" || user.role === "MANAGER" || user.role === "OWNER") {
+        return (
+          <button
+            className="bg-blue-500 text-white py-2 px-6 rounded-[20px] hover:bg-blue-600"
+            onClick={goToAddGroupMember}
+          >
+            {user?.familyId ? "구성원 초대하기" : "그룹 만들기"}
+          </button>
+        );
+      }
+    }
+    return null;
+  };
+
   return (
     <div>
       <HeaderLogoChatNotify />
@@ -68,14 +88,7 @@ function MainPage() {
         {/* 메뉴들 */}
         <div className="px-6 mb-6">
           <div className="mb-6 p-6 flex justify-between items-center bg-[#EBF0FD] py-4 rounded-b-[20px]">
-            <div className="flex-1 flex justify-center">
-              <button
-                className="bg-blue-500 text-white py-2 px-6 rounded-[20px] hover:bg-blue-600"
-                onClick={goToAddGroupMember}
-              >
-                {user?.familyId ? "구성원 초대하기" : "그룹 만들기"}
-              </button>
-            </div>
+            <div className="flex-1 flex justify-center">{renderContent()}</div>
           </div>
           <div className="grid grid-cols-2 gap-x-6 gap-y-4 justify-items-center">
             {/* 가디언 평가 */}

--- a/src/pages/MemberSettingsPage.tsx
+++ b/src/pages/MemberSettingsPage.tsx
@@ -44,7 +44,6 @@ const MemberSettingsPage = () => {
         console.error("그룹 설정 불러오기 실패:", error);
         alert("그룹 설정을 불러오는데 실패했습니다.");
       } finally {
-        console.log(memberSettings);
         setIsLoading(false);
       }
     };
@@ -66,9 +65,9 @@ const MemberSettingsPage = () => {
   // 그룹원 세부 설정 - level 변경
   const handleSaveRole = async () => {
     try {
-      await updateMemberLevel(family_id!, parseInt(target_user_id!), {
-        user_id: parseInt(target_user_id!),
-        user_role: role,
+      await updateMemberLevel(family_id!, {
+        target_user_id: parseInt(target_user_id!),
+        new_role: role,
       });
       goToGroupMemberList();
     } catch (error) {

--- a/src/pages/MemberSettingsPage.tsx
+++ b/src/pages/MemberSettingsPage.tsx
@@ -8,7 +8,7 @@ import {
   getMemberSettingsInfo,
   updateMemberSettings,
   updateMemberLevel,
-} from "@/services/groupSettingsService";
+} from "@/services/memberSettingsService";
 
 import HeaderBackChatNotify from "@/components/Header/HeaderBackChatNotify";
 import InputField from "@/components/common/InputField";
@@ -51,7 +51,7 @@ const MemberSettingsPage = () => {
   // 그룹원 세부 설정 - level 변경
   const handleSaveRole = async () => {
     try {
-      await updateMemberLevel(family_id!, {
+      await updateMemberLevel({
         target_user_id: memberSettings.target_user_id,
         new_role: memberSettings.role,
       });
@@ -67,9 +67,9 @@ const MemberSettingsPage = () => {
     try {
       await updateMemberSettings(family_id!, {
         target_user_id: memberSettings.target_user_id,
+        period: memberSettings.period,
         single_transaction_limit: memberSettings.single_transaction_limit,
         max_limit_amount: memberSettings.max_limit_amount,
-        period: memberSettings.period,
       });
       goToGroupMemberList();
     } catch (error) {

--- a/src/pages/MemberSettingsPage.tsx
+++ b/src/pages/MemberSettingsPage.tsx
@@ -1,59 +1,86 @@
-import { useState } from "react";
-import { TERM_OPTIONS, Term } from "@/constant/term";
+import { useEffect, useState } from "react";
+import { PERIOD_OPTIONS, Period } from "@/constant/period";
 import { Role, ROLE_OPTIONS } from "@/constant/role";
+import { useAuthStore } from "@/stores/userAuthStore";
+import { useNavigation } from "@/hooks/useNavigation";
+import { MemberSettings } from "@/types/GroupSettings";
+import {
+  getMemberSettingsInfo,
+  updateMemberSettings,
+  updateMemberLevel,
+} from "@/services/groupSettingsService";
+
 import HeaderBackChatNotify from "@/components/Header/HeaderBackChatNotify";
 import InputField from "@/components/common/InputField";
 import SelectField from "@/components/common/SelectField";
+import Loading from "@/components/common/Loading";
 
 const MemberSettingsPage = () => {
-  const [role, setRole] = useState<Role>(ROLE_OPTIONS[0]);
-  const [term, setTerm] = useState<Term>(TERM_OPTIONS[0]);
-  const [oneTimeLimit, setOneTimeLimit] = useState("");
-  const [periodLimit, setPeriodLimit] = useState("");
+  const [memberSettings, setMemberSettings] = useState<MemberSettings>({
+    target_user_id: 1, // Assuming this is a constant value
+    role: ROLE_OPTIONS[0],
+    single_transaction_limit: 0,
+    max_limit_amount: 0,
+    period: PERIOD_OPTIONS[0],
+  });
+  const [isLoading, setIsLoading] = useState(true);
+  const { goToGroupMemberList } = useNavigation();
+  const { user } = useAuthStore();
+  const family_id = user?.familyId;
 
-  const handleRoleChange = (value: Role) => {
-    setRole(value);
+  useEffect(() => {
+    const fetchMemberSettings = async () => {
+      try {
+        const fetchedSettings = await getMemberSettingsInfo(family_id!);
+        setMemberSettings(fetchedSettings);
+      } catch (error) {
+        console.error("그룹 설정 불러오기 실패:", error);
+        alert("그룹 설정을 불러오는데 실패했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMemberSettings();
+  }, [family_id]);
+
+  const handleInputChange = (key: keyof MemberSettings) => (value: string | Role | Period) => {
+    setMemberSettings((prev) => ({ ...prev, [key]: value }));
   };
 
-  const handleTermChange = (value: Term) => {
-    setTerm(value);
-  };
-
+  // 그룹원 세부 설정 - level 변경
   const handleSaveRole = async () => {
     try {
-      // API 요청 로직
-      const response = await fetch("/api/save-role", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ role }),
+      await updateMemberLevel(family_id!, {
+        target_user_id: memberSettings.target_user_id,
+        new_role: memberSettings.role,
       });
-      if (!response.ok) throw new Error("Failed to save role");
-      alert("Role saved successfully");
+      goToGroupMemberList();
     } catch (error) {
       console.error("Error saving role:", error);
       alert("Failed to save role");
     }
   };
 
+  // 그룹원 세부 설정 - 기한 및 한도 변경
   const handleSaveLimit = async () => {
     try {
-      // API 요청 로직
-      const response = await fetch("/api/save-limit", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ oneTimeLimit, periodLimit, term }),
+      await updateMemberSettings(family_id!, {
+        target_user_id: memberSettings.target_user_id,
+        single_transaction_limit: memberSettings.single_transaction_limit,
+        max_limit_amount: memberSettings.max_limit_amount,
+        period: memberSettings.period,
       });
-      if (!response.ok) throw new Error("Failed to save limit");
-      alert("Limit saved successfully");
+      goToGroupMemberList();
     } catch (error) {
       console.error("Error saving limit:", error);
       alert("Failed to save limit");
     }
   };
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -65,8 +92,8 @@ const MemberSettingsPage = () => {
             <SelectField<Role>
               label="권한"
               options={ROLE_OPTIONS}
-              value={role}
-              onChange={handleRoleChange}
+              value={memberSettings.role}
+              onChange={handleInputChange("role")}
             />
             <button
               className="text-Button text-md mt-5 me-2 cursor-pointer hover:text-Button"
@@ -84,21 +111,21 @@ const MemberSettingsPage = () => {
               label="1회 한도"
               placeholder="1회 한도를 입력해주세요."
               type="number"
-              value={oneTimeLimit}
-              onChange={setOneTimeLimit}
+              value={memberSettings.single_transaction_limit.toString()}
+              onChange={(value) => handleInputChange("single_transaction_limit")(value)}
             />
             <InputField
               label="기한 한도"
               placeholder="기한 한도를 입력해주세요."
               type="number"
-              value={periodLimit}
-              onChange={setPeriodLimit}
+              value={memberSettings.max_limit_amount.toString()}
+              onChange={(value) => handleInputChange("max_limit_amount")(value)}
             />
-            <SelectField<Term>
-              label="권한"
-              options={TERM_OPTIONS}
-              value={term}
-              onChange={handleTermChange}
+            <SelectField<Period>
+              label="기한"
+              options={PERIOD_OPTIONS}
+              value={memberSettings.period}
+              onChange={handleInputChange("period")}
             />
             <button
               className="text-Button text-md mt-5 me-2 cursor-pointer hover:text-Button"

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,4 +1,3 @@
-// src/router.tsx
 import { createBrowserRouter } from "react-router-dom";
 import App from "@/App";
 import SplashScreen from "@/pages/SplashScreen";
@@ -37,7 +36,7 @@ const router = createBrowserRouter([
         element: <GroupMemberListPage />,
       },
       {
-        path: "memberSettings",
+        path: "memberSettings/:target_user_id",
         element: <MemberSettingsPage />,
       },
       {

--- a/src/services/groupMemberService.ts
+++ b/src/services/groupMemberService.ts
@@ -1,9 +1,9 @@
 import axiosInstance from "./axiosInstance";
-import { FamilyResponse } from "@/types/Response";
+import { GroupListResponse } from "@/types/GroupSettings";
 
-export const getGroupMemberList = async (familyId: string): Promise<FamilyResponse> => {
+export const getGroupMemberList = async (familyId: string): Promise<GroupListResponse> => {
   try {
-    const response = await axiosInstance.get<FamilyResponse>(`/family/${familyId}`);
+    const response = await axiosInstance.get<GroupListResponse>(`/family/${familyId}`);
     return response.data;
   } catch (error) {
     console.error("Failed to fetch group member list", error);

--- a/src/services/groupMemberService.ts
+++ b/src/services/groupMemberService.ts
@@ -1,7 +1,7 @@
 import axiosInstance from "./axiosInstance";
 import { GroupListResponse } from "@/types/GroupSettings";
 
-export const getGroupMemberList = async (familyId: string): Promise<GroupListResponse> => {
+export const getGroupMemberList = async (familyId: number): Promise<GroupListResponse> => {
   try {
     const response = await axiosInstance.get<GroupListResponse>(`/family/${familyId}/users`);
     return response.data;
@@ -12,7 +12,7 @@ export const getGroupMemberList = async (familyId: string): Promise<GroupListRes
 };
 
 export const postGroupMemberInvite = async (
-  familyId: string,
+  familyId: number,
   name: string,
   phone_number: string
 ): Promise<void> => {

--- a/src/services/groupMemberService.ts
+++ b/src/services/groupMemberService.ts
@@ -3,7 +3,7 @@ import { GroupListResponse } from "@/types/GroupSettings";
 
 export const getGroupMemberList = async (familyId: string): Promise<GroupListResponse> => {
   try {
-    const response = await axiosInstance.get<GroupListResponse>(`/family/${familyId}`);
+    const response = await axiosInstance.get<GroupListResponse>(`/family/${familyId}/users`);
     return response.data;
   } catch (error) {
     console.error("Failed to fetch group member list", error);

--- a/src/services/groupSettingsService.ts
+++ b/src/services/groupSettingsService.ts
@@ -1,11 +1,5 @@
 import axiosInstance from "./axiosInstance";
-import {
-  GroupSettings,
-  GroupSettingsRequest,
-  MemberSettings,
-  MemberSettingsRequest,
-  MemberLevelSettingsRequest,
-} from "@/types/GroupSettings";
+import { GroupSettings, GroupSettingsRequest } from "@/types/GroupSettings";
 
 // 그룹 세부 설정 받아오기
 export const getGroupSettingsInfo = async (family_id: string): Promise<GroupSettings> => {
@@ -20,49 +14,14 @@ export const getGroupSettingsInfo = async (family_id: string): Promise<GroupSett
 };
 
 // 그룹 세부 설정 수정하기
-export const updateGroupSettings = async (settings: GroupSettingsRequest): Promise<void> => {
+export const updateGroupSettings = async (
+  family_id: string,
+  settings: GroupSettingsRequest
+): Promise<void> => {
   try {
-    await axiosInstance.put(`/limit`, settings);
-  } catch (error) {
-    console.error("Error updating group settings:", error);
-    throw error;
-  }
-};
-
-// 그룹원 세부 설정 받아오기
-export const getMemberSettingsInfo = async (family_id: string): Promise<MemberSettings> => {
-  try {
-    const response = await axiosInstance.get<MemberSettings>(`/family/${family_id}`);
-    console.log(response.data);
-    return response.data;
+    await axiosInstance.put<GroupSettings>(`/family/${family_id}`, settings);
   } catch (error) {
     console.error("Error fetching group info:", error);
-    throw error;
-  }
-};
-
-// 그룹원 세부 설정 - 권한 설정 수정
-export const updateMemberLevel = async (
-  family_id: string,
-  settings: MemberLevelSettingsRequest
-): Promise<void> => {
-  try {
-    await axiosInstance.put(`/family/${family_id}/userRole`, settings);
-  } catch (error) {
-    console.error("Error updating group settings:", error);
-    throw error;
-  }
-};
-
-// 그룹원 세부 설정 - 한도 설정 수정
-export const updateMemberSettings = async (
-  family_id: string,
-  settings: MemberSettingsRequest
-): Promise<void> => {
-  try {
-    await axiosInstance.put(`/family/${family_id}/userRole`, settings);
-  } catch (error) {
-    console.error("Error updating group settings:", error);
     throw error;
   }
 };

--- a/src/services/groupSettingsService.ts
+++ b/src/services/groupSettingsService.ts
@@ -2,7 +2,7 @@ import axiosInstance from "./axiosInstance";
 import { GroupSettings, GroupSettingsRequest } from "@/types/GroupSettings";
 
 // 그룹 세부 설정 받아오기
-export const getGroupSettingsInfo = async (family_id: string): Promise<GroupSettings> => {
+export const getGroupSettingsInfo = async (family_id: number): Promise<GroupSettings> => {
   try {
     const response = await axiosInstance.get<GroupSettings>(`/family/${family_id}`);
     return response.data;
@@ -14,7 +14,7 @@ export const getGroupSettingsInfo = async (family_id: string): Promise<GroupSett
 
 // 그룹 세부 설정 수정하기
 export const updateGroupSettings = async (
-  family_id: string,
+  family_id: number,
   settings: GroupSettingsRequest
 ): Promise<void> => {
   try {

--- a/src/services/groupSettingsService.ts
+++ b/src/services/groupSettingsService.ts
@@ -1,22 +1,66 @@
 import axiosInstance from "./axiosInstance";
-import { GroupSettings } from "@/types/GroupSettings";
+import {
+  GroupSettings,
+  GroupSettingsRequest,
+  MemberSettings,
+  MemberSettingsRequest,
+  MemberLevelSettingsRequest,
+} from "@/types/GroupSettings";
 
-export const updateGroupSettings = async (
+// 그룹 세부 설정 받아오기
+export const getGroupSettingsInfo = async (family_id: string): Promise<GroupSettings> => {
+  try {
+    const response = await axiosInstance.get<GroupSettings>(`/family/${family_id}`);
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching group info:", error);
+    throw error;
+  }
+};
+
+// 그룹 세부 설정 수정하기
+export const updateGroupSettings = async (settings: GroupSettingsRequest): Promise<void> => {
+  try {
+    await axiosInstance.put(`/limit`, settings);
+  } catch (error) {
+    console.error("Error updating group settings:", error);
+    throw error;
+  }
+};
+
+// 그룹원 세부 설정 받아오기
+export const getMemberSettingsInfo = async (family_id: string): Promise<MemberSettings> => {
+  try {
+    const response = await axiosInstance.get<MemberSettings>(`/family/${family_id}`);
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching group info:", error);
+    throw error;
+  }
+};
+
+// 그룹원 세부 설정 - 권한 설정 수정
+export const updateMemberLevel = async (
   family_id: string,
-  settings: GroupSettings
+  settings: MemberLevelSettingsRequest
 ): Promise<void> => {
   try {
-    const response = await axiosInstance.put(`/family/${family_id}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(settings),
-    });
+    await axiosInstance.put(`/family/${family_id}/userRole`, settings);
+  } catch (error) {
+    console.error("Error updating group settings:", error);
+    throw error;
+  }
+};
 
-    if (!response) {
-      throw new Error("Failed to update group settings");
-    }
+// 그룹원 세부 설정 - 한도 설정 수정
+export const updateMemberSettings = async (
+  family_id: string,
+  settings: MemberSettingsRequest
+): Promise<void> => {
+  try {
+    await axiosInstance.put(`/family/${family_id}/userRole`, settings);
   } catch (error) {
     console.error("Error updating group settings:", error);
     throw error;

--- a/src/services/groupSettingsService.ts
+++ b/src/services/groupSettingsService.ts
@@ -5,7 +5,6 @@ import { GroupSettings, GroupSettingsRequest } from "@/types/GroupSettings";
 export const getGroupSettingsInfo = async (family_id: string): Promise<GroupSettings> => {
   try {
     const response = await axiosInstance.get<GroupSettings>(`/family/${family_id}`);
-    console.log(response.data);
     return response.data;
   } catch (error) {
     console.error("Error fetching group info:", error);

--- a/src/services/memberSettingsService.ts
+++ b/src/services/memberSettingsService.ts
@@ -1,0 +1,41 @@
+import axiosInstance from "./axiosInstance";
+import {
+  MemberSettings,
+  MemberSettingsRequest,
+  MemberLevelSettingsRequest,
+} from "@/types/GroupSettings";
+
+// 그룹원 세부 설정 받아오기
+export const getMemberSettingsInfo = async (family_id: string): Promise<MemberSettings> => {
+  try {
+    const response = await axiosInstance.get<MemberSettings>(`/family/${family_id}`);
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching group info:", error);
+    throw error;
+  }
+};
+
+// 그룹원 세부 설정 - 한도 설정 수정
+export const updateMemberSettings = async (
+  family_id: string,
+  settings: MemberSettingsRequest
+): Promise<void> => {
+  try {
+    await axiosInstance.put(`/family/${family_id}/userRole`, settings);
+  } catch (error) {
+    console.error("Error updating group settings:", error);
+    throw error;
+  }
+};
+
+// 그룹원 세부 설정 - 권한 설정 수정
+export const updateMemberLevel = async (settings: MemberLevelSettingsRequest): Promise<void> => {
+  try {
+    await axiosInstance.put(`/limit`, settings);
+  } catch (error) {
+    console.error("Error updating group settings:", error);
+    throw error;
+  }
+};

--- a/src/services/memberSettingsService.ts
+++ b/src/services/memberSettingsService.ts
@@ -10,7 +10,6 @@ import {
 export const getMemberSettingsInfo = async (target_user_id: number): Promise<MemberSettings> => {
   try {
     const response = await axiosInstance.get<MemberSettings>(`/limit/user/${target_user_id}`);
-    console.log(response.data);
     return response.data;
   } catch (error) {
     console.error("Error fetching group settings info:", error);
@@ -45,12 +44,10 @@ export const updateMemberSettings = async (settings: MemberSettingsRequest): Pro
 // 그룹원 세부 설정 - 권한 설정 수정
 export const updateMemberLevel = async (
   family_id: number,
-  target_user_id: number,
   settings: MemberLevelSettingsRequest
 ): Promise<void> => {
   try {
-    console.log(settings);
-    await axiosInstance.put(`/family/${family_id}/userRole/${target_user_id}`, settings);
+    await axiosInstance.post(`/family/${family_id}/userRole`, settings);
   } catch (error) {
     console.error("Error updating member level:", error);
     throw error;

--- a/src/services/memberSettingsService.ts
+++ b/src/services/memberSettingsService.ts
@@ -1,3 +1,4 @@
+import { Role } from "@/constant/role";
 import axiosInstance from "./axiosInstance";
 import {
   MemberSettings,
@@ -5,37 +6,53 @@ import {
   MemberLevelSettingsRequest,
 } from "@/types/GroupSettings";
 
-// 그룹원 세부 설정 받아오기
-export const getMemberSettingsInfo = async (family_id: string): Promise<MemberSettings> => {
+// 그룹원 세부 설정 - 한도 받아오기
+export const getMemberSettingsInfo = async (target_user_id: number): Promise<MemberSettings> => {
   try {
-    const response = await axiosInstance.get<MemberSettings>(`/family/${family_id}`);
+    const response = await axiosInstance.get<MemberSettings>(`/limit/user/${target_user_id}`);
     console.log(response.data);
     return response.data;
   } catch (error) {
-    console.error("Error fetching group info:", error);
+    console.error("Error fetching group settings info:", error);
+    throw error;
+  }
+};
+
+// 그룹원 세부 설정 - 권한 받아오기
+export const getMemberLevelInfo = async (
+  family_id: number,
+  target_user_id: number
+): Promise<{ user_id: string; role: Role }> => {
+  try {
+    const response = await axiosInstance.get(`/family/${family_id}/userRole/${target_user_id}`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching member level info:", error);
     throw error;
   }
 };
 
 // 그룹원 세부 설정 - 한도 설정 수정
-export const updateMemberSettings = async (
-  family_id: string,
-  settings: MemberSettingsRequest
-): Promise<void> => {
+export const updateMemberSettings = async (settings: MemberSettingsRequest): Promise<void> => {
   try {
-    await axiosInstance.put(`/family/${family_id}/userRole`, settings);
+    await axiosInstance.put(`/limit`, settings);
   } catch (error) {
-    console.error("Error updating group settings:", error);
+    console.error("Error updating member settings:", error);
     throw error;
   }
 };
 
 // 그룹원 세부 설정 - 권한 설정 수정
-export const updateMemberLevel = async (settings: MemberLevelSettingsRequest): Promise<void> => {
+export const updateMemberLevel = async (
+  family_id: number,
+  target_user_id: number,
+  settings: MemberLevelSettingsRequest
+): Promise<void> => {
   try {
-    await axiosInstance.put(`/limit`, settings);
+    console.log(settings);
+    await axiosInstance.put(`/family/${family_id}/userRole/${target_user_id}`, settings);
   } catch (error) {
-    console.error("Error updating group settings:", error);
+    console.error("Error updating member level:", error);
     throw error;
   }
 };

--- a/src/types/GroupSettings.ts
+++ b/src/types/GroupSettings.ts
@@ -1,6 +1,46 @@
+import { Member } from "@/types/Member";
+
+export interface GroupListResponse {
+  name: string;
+  description: string;
+  approval_request: number;
+  user_list: Member[];
+}
+
+// 그룹 세부 설정 받아오기
 export interface GroupSettings {
-  groupName: string;
-  groupMotto: string;
-  approvalLimit: number;
-  creationDate: string;
+  name: string;
+  description: string;
+  approval_requirement: number;
+  creation_date: Date;
+}
+
+// 그룹 세부 설정 수정하기
+export interface GroupSettingsRequest {
+  name: string;
+  description: string;
+  approval_requirement: number;
+}
+
+// 그룹원 세부 설정 받아오기
+export interface MemberSettings {
+  target_user_id: number;
+  role: "MEMBER" | "MANAGER";
+  single_transaction_limit: number;
+  max_limit_amount: number;
+  period: string;
+}
+
+// 그룹원 세부 설정 수정하기
+export interface MemberSettingsRequest {
+  target_user_id: number;
+  single_transaction_limit: number;
+  max_limit_amount: number;
+  period: string;
+}
+
+// 그룹원 세부 설정 level 수정하기
+export interface MemberLevelSettingsRequest {
+  target_user_id: number;
+  new_role: "MEMBER" | "MANAGER";
 }

--- a/src/types/GroupSettings.ts
+++ b/src/types/GroupSettings.ts
@@ -40,6 +40,6 @@ export interface MemberSettingsRequest {
 
 // 그룹원 세부 설정 level 수정하기
 export interface MemberLevelSettingsRequest {
-  user_id: number;
-  user_role: "MEMBER" | "MANAGER";
+  target_user_id: number;
+  new_role: "MEMBER" | "MANAGER";
 }

--- a/src/types/GroupSettings.ts
+++ b/src/types/GroupSettings.ts
@@ -11,8 +11,8 @@ export interface GroupListResponse {
 export interface GroupSettings {
   name: string;
   description: string;
-  approval_requirement: number;
-  creation_date: Date;
+  approval_request: number;
+  created_at: string;
 }
 
 // 그룹 세부 설정 수정하기

--- a/src/types/GroupSettings.ts
+++ b/src/types/GroupSettings.ts
@@ -34,9 +34,9 @@ export interface MemberSettings {
 // 그룹원 세부 설정 수정하기
 export interface MemberSettingsRequest {
   target_user_id: number;
+  period: string;
   single_transaction_limit: number;
   max_limit_amount: number;
-  period: string;
 }
 
 // 그룹원 세부 설정 level 수정하기

--- a/src/types/GroupSettings.ts
+++ b/src/types/GroupSettings.ts
@@ -25,10 +25,9 @@ export interface GroupSettingsRequest {
 // 그룹원 세부 설정 받아오기
 export interface MemberSettings {
   target_user_id: number;
-  role: "MEMBER" | "MANAGER";
+  period: string;
   single_transaction_limit: number;
   max_limit_amount: number;
-  period: string;
 }
 
 // 그룹원 세부 설정 수정하기
@@ -41,6 +40,6 @@ export interface MemberSettingsRequest {
 
 // 그룹원 세부 설정 level 수정하기
 export interface MemberLevelSettingsRequest {
-  target_user_id: number;
-  new_role: "MEMBER" | "MANAGER";
+  user_id: number;
+  user_role: "MEMBER" | "MANAGER";
 }

--- a/src/types/Response.ts
+++ b/src/types/Response.ts
@@ -1,12 +1,3 @@
-import { Member } from "./Member";
-
-export interface FamilyResponse {
-  name: string;
-  description: string;
-  approval_request: number;
-  user_list: Member[];
-}
-
 export interface ChatBotHistoryResponse {
   userId: string;
   message: string;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,8 +1,8 @@
 export interface User {
-  userId: string;
+  userId: number;
   userName: string;
   level: "GUARDIAN" | "SUPPORTER";
   role: "NONE" | "MEMBER" | "MANAGER" | "OWNER";
-  familyId: string;
+  familyId: number;
   familyName: string;
 }


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- #51 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- 그룹 및 그룹 세팅에 관한 api 구현

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- 그룹 리스트 불러오기
- 그룹 세팅 불러오기
- 그룹 세팅 수정하기
- 그룹원 세팅 불러오기
- 그룹원 세팅 수정하기(매니저, 오너만)
- 그룹원 룰 불러오기(오너는 X)
- 그룹원 룰 수정하기(오너는 X)
- 멤버라면 그룹 세팅 헤더에서 비활성화
- 멤버라면 그룹원 아이템 클릭 비활성화

## 기타 <!-- 기타 공유할 내용이 있다면 작성해주세요. -->

- 그룹원 추가하기(아직 체크 못함)
- 
